### PR TITLE
Add support to `externalincludedirs`

### DIFF
--- a/qmake_project.lua
+++ b/qmake_project.lua
@@ -234,6 +234,13 @@ function m.includepath(cfg)
 		end
 		qmake.popVariable()
 	end
+	if #cfg.externalincludedirs > 0 then
+		qmake.pushVariable("QMAKE_INCDIR")
+		for _, includedir in ipairs(cfg.externalincludedirs) do
+			p.w('"%s"', p.project.getrelative(cfg.project, includedir))
+		end
+		qmake.popVariable()
+	end
 end
 
 --


### PR DESCRIPTION
Add support to `externalincludedirs`(and deprecated `sysincludedirs`).

For info:
I just added your module in my premake testing [repo](https://github.com/Jarod42/premake-sample-projects).
Lot of features are not passing with your repo.
I will try to fix some of them.
