### PR TITLE
Avoid to globally `override` functions

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -45,6 +45,33 @@ newaction {
 
 	toolset = default_toolset(),
 
+	onStart = function()
+		--
+		-- Overloaded functions
+		--
+		p.override(p.tools.gcc, "getLibraryDirectories",
+			-- Relative paths in library directories should be prepended with '$$PWD'
+			-- To achieve this, we override the 'p.quoted' function that just so happens to be inserted after every '-L'
+			function(base, cfg)
+				local originalquoted = p.quoted
+				p.quoted = function(value)
+					if not path.isabsolute(value) then
+						value = path.join("$$PWD", value)
+					end
+					return originalquoted(value)
+				end
+
+				local result = base(cfg)
+
+				-- Restore 'p.quoted' to its original function
+				p.quoted = originalquoted
+
+				return result
+			end
+		)
+	end,
+
+
 	-- Workspace generation
 
 	onWorkspace = function(wks)

--- a/qmake.lua
+++ b/qmake.lua
@@ -17,31 +17,6 @@ p.api.register {
 }
 
 --
--- Overloaded functions
---
-
-p.override(p.tools.gcc, "getLibraryDirectories",
-	-- Relative paths in library directories should be prepended with '$$PWD'
-	-- To achieve this, we override the 'p.quoted' function that just so happens to be inserted after every '-L'
-	function(base, cfg)
-		local originalquoted = p.quoted
-		p.quoted = function(value)
-			if not path.isabsolute(value) then
-				value = path.join("$$PWD", value)
-			end
-			return originalquoted(value)
-		end
-
-		local result = base(cfg)
-
-		-- Restore 'p.quoted' to its original function
-		p.quoted = originalquoted
-
-		return result
-	end
-)
-
---
 -- Utility functions
 --
 


### PR DESCRIPTION
 to not break other actions when module is loaded.

I put `require 'premake-qmake/qmake'` in premake5-system.lua (and other generator modules).
and without that fix, `$$PWD` is also prepend for other generators :-/